### PR TITLE
6 sticknote api

### DIFF
--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class NotesController extends Controller
+{
+    //
+    public function create()
+    {
+        return "It's work";
+    }
+}

--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -3,12 +3,35 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Validator;
 
 class NotesController extends Controller
 {
-    //
-    public function create()
+
+    public function create(Request $request)
     {
-        return "It's work";
+        $execResult = [
+            "error" => false,
+            "message" => ""
+        ];
+
+        /*
+        | ---------------------------------------------------------------------
+        |    Validação da requisição
+        | ---------------------------------------------------------------------
+       */
+        $validationRules = [
+            "note" => "required|min:5|max:255"
+        ];
+
+        $validator = Validator::make($request->only('note'), $validationRules);
+
+        if($validator->fails())
+        {
+            $execResult['error']   = true;
+            $execResult['message'] = $validator->getMessageBag();
+        }
+
+        return json_encode($execResult);
     }
 }

--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Validator;
+use App\Models\Note;
 
 class NotesController extends Controller
 {
@@ -15,11 +16,7 @@ class NotesController extends Controller
             "message" => ""
         ];
 
-        /*
-        | ---------------------------------------------------------------------
-        |    Validação da requisição
-        | ---------------------------------------------------------------------
-       */
+        #  Validação da requisição
         $validationRules = [
             "note" => "required|min:5|max:255"
         ];
@@ -30,7 +27,14 @@ class NotesController extends Controller
         {
             $execResult['error']   = true;
             $execResult['message'] = $validator->getMessageBag();
+
+            return $execResult;
         }
+
+        # Salvando a nova anotação
+        $newNote        = new Note();
+        $newNote->note  = $request->note;
+        $newNote->save();
 
         return json_encode($execResult);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\NotesController;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,6 +15,8 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
-});
+#Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+#    return $request->user();
+#});
+
+Route::post('/note/create', [NotesController::class, 'create'])->name('note.create');

--- a/tests/Feature/NotesCreateTest.php
+++ b/tests/Feature/NotesCreateTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NotesCreateTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function test_create_note_route_is_accessible()
+    {
+        $response = $this->post('/api/note/create');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/NotesCreateTest.php
+++ b/tests/Feature/NotesCreateTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Models\Note;
 
 class NotesCreateTest extends TestCase
 {
@@ -18,4 +19,20 @@ class NotesCreateTest extends TestCase
 
         $response->assertStatus(200);
     }
+
+    public function test_is_able_to_save_a_new_note()
+    {
+        $params   = ["note" => "nota-de-teste-74289374098237"];
+        $response = $this->post('/api/note/create', $params);
+
+        # Remove a nota de teste
+        $nota = Note::where($params)->delete();
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                    'error' => false
+                 ]);
+
+    }
+    
 }


### PR DESCRIPTION
**Concluído**

- [x]  Rota "/note/create" apta a receber requisições POST com o conteúdo da nota a ser salva
- [x]  Em caso de falha, o usuário é notificado que ocorreu um erro e uma chamada para ação (caso necessário)
- [x]  Em caso de sucesso, o usuário é informado que a nota foi salva com sucesso
- [x]  Criação de testes para validar a consistência da funcionalidade.