### PR TITLE
8 obter uma ou mais notas

### DIFF
--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -52,8 +52,28 @@ class NotesController extends Controller
         return json_encode($execResult);
     }
 
-    public function select()
+    public function select(Request $request)
     {
-        return "selectNote";
+        $execResult = [
+            "error"   => false,
+            "message" => "",
+            "note"   => []
+        ];
+
+        $noteId = $request->id;
+
+        $note = Note::find($noteId);
+
+        if(empty($note))
+        {
+            $execResult["error"]   = true;
+            $execResult["message"] = "Nota não encontrada";
+        }
+        else
+        {
+            $execResult["note"] = $note;
+        }
+
+        return $execResult;
     }
 }

--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -38,4 +38,9 @@ class NotesController extends Controller
 
         return json_encode($execResult);
     }
+
+    public function getAll(Request $request)
+    {
+        return "Its Work";
+    }
 }

--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -39,8 +39,16 @@ class NotesController extends Controller
         return json_encode($execResult);
     }
 
-    public function getAll(Request $request)
+    public function getAll()
     {
-        return "Its Work";
+        $execResult = [
+            "error"   => false,
+            "message" => "",
+            "notes"   => []
+        ];
+
+        $execResult["notes"] = Note::all();
+
+        return json_encode($execResult);
     }
 }

--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -51,4 +51,9 @@ class NotesController extends Controller
 
         return json_encode($execResult);
     }
+
+    public function select()
+    {
+        return "selectNote";
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,3 +20,4 @@ use App\Http\Controllers\NotesController;
 #});
 
 Route::post('/note/create', [NotesController::class, 'create'])->name('note.create');
+Route::post('/notes', [NotesController::class, 'getAll'])->name('note.getAll');

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,4 +20,4 @@ use App\Http\Controllers\NotesController;
 #});
 
 Route::post('/note/create', [NotesController::class, 'create'])->name('note.create');
-Route::post('/notes', [NotesController::class, 'getAll'])->name('note.getAll');
+Route::get('/notes', [NotesController::class, 'getAll'])->name('note.getAll');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,3 +21,4 @@ use App\Http\Controllers\NotesController;
 
 Route::post('/note/create', [NotesController::class, 'create'])->name('note.create');
 Route::get('/notes', [NotesController::class, 'getAll'])->name('note.getAll');
+Route::get('/note/{id}', [NotesController::class, 'select'])->name('note.select');

--- a/tests/Feature/NotesSelectTest.php
+++ b/tests/Feature/NotesSelectTest.php
@@ -30,5 +30,22 @@ class NotesSelectTest extends TestCase
                     'notes' => []
                  ]);
     }
+
+    public function test_route_to_select_a_single_note_is_accessible()
+    {
+        $randomInt = random_int(1,999);
+        $response = $this->get('/api/note/' . $randomInt);
+
+        $response->assertStatus(200);
+    }
     
+    public function test_is_able_to_return_a_single_note()
+    {
+        $response = $this->get('/api/note/999');
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                    'note' => []
+                 ]);
+    }
 }

--- a/tests/Feature/NotesSelectTest.php
+++ b/tests/Feature/NotesSelectTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Note;
+
+class NotesSelectTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function test_route_select_all_notes_is_accessible()
+    {
+        $response = $this->get('/api/notes');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_is_able_to_return_a_list_of_notes()
+    {
+        $response = $this->get('/api/notes');
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                    'error' => false,
+                    'notes' => []
+                 ]);
+    }
+    
+}


### PR DESCRIPTION
Listar uma ou mais notas através de uma requisição HTTP


- [x]  Rota "/notes" apta a receber requisições GET, para retornar a lista com todas as notas armazenadas
- [x]  Rota "/note/{id}" apta a receber requisições GET, para retornar a nota com a id informada
-  - [x]  Caso a nota com a id informada não for encontrada, informar ao usuário que a nota não existe.
- [x]  Em caso de sucesso, o usuário recebe uma lista com as notas armazenadas
- [x]  Criação de testes para validar a consistência da funcionalidade de exibição de notas.