### PR TITLE
Edicao de notas#10

### DIFF
--- a/app/Http/Controllers/NotesController.php
+++ b/app/Http/Controllers/NotesController.php
@@ -76,4 +76,65 @@ class NotesController extends Controller
 
         return $execResult;
     }
+
+    public function update(Request $request)
+    {
+        $execResult = [
+            "error"   => false,
+            "message" => ""
+        ];
+
+        #  Validação da requisição
+        $validationRules = [
+            "note"  => "min:5|max:255",
+            "id"    => "required|integer",
+            "done"  => "boolean"
+        ];
+
+        $validator = Validator::make($request->all(), $validationRules);
+
+        if($validator->fails())
+        {
+            $execResult['error']   = true;
+            $execResult['message'] = $validator->getMessageBag();
+
+            return json_encode($execResult);
+        }
+
+        $params = $request->all();
+
+        # verificando se o campo done ou note foram informados
+        if( !isset($params['done']) && !isset($params['note']) )
+        {
+            $execResult['error']   = true;
+            $execResult['message'] = "Não foi possível atualizar os dados. Informe os parâmetros note ou done";
+
+            return json_encode($execResult);
+        }
+
+        # Faz a busca de um registro válido
+        $noteId      = $request->id;
+        $noteUpdated = Note::find($noteId);
+
+        if(empty($noteUpdated))
+        {
+            $execResult['error']   = true;
+            $execResult['message'] = "Não foi encontrado nenhum registro de nota com o id informado";
+
+            return $execResult;
+        }
+
+        # atualiza os dados solicitados
+        if(empty($request->note) == FALSE)
+        {
+            $noteUpdated->note  = $request->note;
+        }
+
+        if(empty($request->done) == FALSE)
+        {
+            $noteUpdated->done  = $request->done;
+        }
+
+        return json_encode($execResult);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,3 +22,4 @@ use App\Http\Controllers\NotesController;
 Route::post('/note/create', [NotesController::class, 'create'])->name('note.create');
 Route::get('/notes', [NotesController::class, 'getAll'])->name('note.getAll');
 Route::get('/note/{id}', [NotesController::class, 'select'])->name('note.select');
+Route::put('/note/update', [NotesController::class, 'update'])->name('note.update');

--- a/tests/Feature/NotesUpdateTest.php
+++ b/tests/Feature/NotesUpdateTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Note;
+
+class NotesUpdateTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function test_route_to_update_note_is_accessible()
+    {
+        $response = $this->put('/api/note/update');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_is_able_to_update_a_note_by_id()
+    {
+
+        $params   = ["id" => 1, 'done' => 0];
+
+        $response = $this->put('/api/note/update', $params);
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                    'error'    => false
+                 ]);
+    }
+
+}


### PR DESCRIPTION
**Editar o conteúdo de uma nota através de uma requisição HTTP**

- [x]  Rota "/note/update" apta a receber requisições PUT, com os parâmetros **id** e **note**, referentes a nota que será atualizada.
-  - [x]  Caso a nota com a id informada não for encontrada, informar ao usuário que a nota não existe.
- [x]  Em caso de sucesso, o usuário recebe uma resposta informando que não ocorreram erros durante o processo de atualização.
- [x]  Criação de testes para validar a consistência da funcionalidade de edição de notas criadas.